### PR TITLE
Exposed containsEmoji() to Objective C

### DIFF
--- a/Sources/NSString+RemoveEmoji.swift
+++ b/Sources/NSString+RemoveEmoji.swift
@@ -10,8 +10,8 @@ import Foundation
 
 private extension UInt32 {
     static let combiningEnclosingKeycap: UInt32 = 0x20E3
-    static let validationSelector15: UInt32 = 0xFE0E
-    static let validationSelector16: UInt32 = 0xFE0F
+    static let variationSelector15: UInt32 = 0xFE0E
+    static let variationSelector16: UInt32 = 0xFE0F
 }
 
 public extension NSString {
@@ -20,8 +20,8 @@ public extension NSString {
         let codepoints = (self as String).unicodeScalars.map { $0.value }
         
         if let first = codepoints.first, let last = codepoints.last {
-            let isKeycapEmoji = last == .combiningEnclosingKeycap && codepoints.contains(.validationSelector16)
-            let isEmoji = CodePointSet.contains(first) && last != .validationSelector15
+            let isKeycapEmoji = last == .combiningEnclosingKeycap && codepoints.contains(.variationSelector16)
+            let isEmoji = CodePointSet.contains(first) && last != .variationSelector15
             
             return isKeycapEmoji || isEmoji
         } else {

--- a/Sources/NSString+RemoveEmoji.swift
+++ b/Sources/NSString+RemoveEmoji.swift
@@ -8,17 +8,20 @@
 
 import Foundation
 
-fileprivate let CombiningEnclosingKeycap: UInt32 = 0x20E3
-fileprivate let VaridationSelector15: UInt32 = 0xFE0E
-fileprivate let VaridationSelector16: UInt32 = 0xFE0F
+private extension UInt32 {
+    static let combiningEnclosingKeycap: UInt32 = 0x20E3
+    static let varidationSelector15: UInt32 = 0xFE0E
+    static let varidationSelector16: UInt32 = 0xFE0F
+}
 
 public extension NSString {
+    @objc
     public func containsEmoji() -> Bool {
         let codepoints = (self as String).unicodeScalars.map { $0.value }
         
         if let first = codepoints.first, let last = codepoints.last {
-            let isKeycapEmoji = last == CombiningEnclosingKeycap && codepoints.contains(VaridationSelector16)
-            let isEmoji = CodePointSet.contains(first) && last != VaridationSelector15
+            let isKeycapEmoji = last == .combiningEnclosingKeycap && codepoints.contains(.varidationSelector16)
+            let isEmoji = CodePointSet.contains(first) && last != .varidationSelector15
             
             return isKeycapEmoji || isEmoji
         } else {

--- a/Sources/NSString+RemoveEmoji.swift
+++ b/Sources/NSString+RemoveEmoji.swift
@@ -10,8 +10,8 @@ import Foundation
 
 private extension UInt32 {
     static let combiningEnclosingKeycap: UInt32 = 0x20E3
-    static let varidationSelector15: UInt32 = 0xFE0E
-    static let varidationSelector16: UInt32 = 0xFE0F
+    static let validationSelector15: UInt32 = 0xFE0E
+    static let validationSelector16: UInt32 = 0xFE0F
 }
 
 public extension NSString {
@@ -20,8 +20,8 @@ public extension NSString {
         let codepoints = (self as String).unicodeScalars.map { $0.value }
         
         if let first = codepoints.first, let last = codepoints.last {
-            let isKeycapEmoji = last == .combiningEnclosingKeycap && codepoints.contains(.varidationSelector16)
-            let isEmoji = CodePointSet.contains(first) && last != .varidationSelector15
+            let isKeycapEmoji = last == .combiningEnclosingKeycap && codepoints.contains(.validationSelector16)
+            let isEmoji = CodePointSet.contains(first) && last != .validationSelector15
             
             return isKeycapEmoji || isEmoji
         } else {


### PR DESCRIPTION
In order to be able to call `containsEmoji()` from Objective C in Swift 4.1 it needs to be exposed and therefore annotated with `@objc`